### PR TITLE
Fix up sigint() signature

### DIFF
--- a/evhz.c
+++ b/evhz.c
@@ -33,7 +33,8 @@ typedef struct event_s {
 
 int quit = 0;
 
-void sigint() {
+void sigint(int a) {
+	(void)a;
     quit = 1;
 }
 


### PR DESCRIPTION
signal() expects void (*)(int), but the function was missing the argument. On my system, GCC 15.1.1 emits a warning for this, and for an unknown reason, treats this warning as an error, so this change fixes the build on this newer version of GCC.